### PR TITLE
extendParams auth logic seems incorrect

### DIFF
--- a/soundcloud/apierror.go
+++ b/soundcloud/apierror.go
@@ -6,22 +6,22 @@ import (
 )
 
 type ApiError struct {
-	Repr     string
-  URL string
-	Code int
-  Message string
+	Repr    string
+	URL     string
+	Code    int
+	Message string
 }
 
 type errorResponse struct {
-  Error interface{}
+	Error interface{}
 }
 
 func newApiError(req *http.Request, resp *http.Response) *ApiError {
-  errResp := new(errorResponse)
-  err := decodeResponse(resp.Body, errResp)
-  if err != nil {
-    errResp.Error = "<could not read body>"
-  }
+	errResp := new(errorResponse)
+	err := decodeResponse(resp.Body, errResp)
+	if err != nil {
+		errResp.Error = "<could not read body>"
+	}
 
 	repr := fmt.Sprintf("Bad response code %d", resp.StatusCode)
 	return &ApiError{Repr: repr, Code: resp.StatusCode, URL: req.URL.String(), Message: fmt.Sprintf("%v", errResp.Error)}

--- a/soundcloud/core.go
+++ b/soundcloud/core.go
@@ -80,11 +80,11 @@ func (api *Api) extendParams(p url.Values, auth ...bool) (url.Values, error) {
 	}
 
 	if !(len(auth) > 0 && auth[0]) {
-    if api.AccessToken != "" {
-      p.Set("oauth_token", api.AccessToken)
-    } else {
-      return p, errors.New("Access token required to use this endpoint")
-    }
+		if api.AccessToken != "" {
+			p.Set("oauth_token", api.AccessToken)
+		} else {
+			return p, errors.New("Access token required to use this endpoint")
+		}
 	} else {
 		p.Set("client_id", api.ClientId)
 	}

--- a/soundcloud/core.go
+++ b/soundcloud/core.go
@@ -79,7 +79,7 @@ func (api *Api) extendParams(p url.Values, auth ...bool) (url.Values, error) {
 		p = url.Values{}
 	}
 
-	if !(len(auth) > 0 && auth[0]) {
+	if len(auth) > 0 && auth[0] {
 		if api.AccessToken != "" {
 			p.Set("oauth_token", api.AccessToken)
 		} else {

--- a/soundcloud/me_test.go
+++ b/soundcloud/me_test.go
@@ -1,15 +1,15 @@
 package soundcloud
 
 import (
-  "testing"
+	"testing"
 )
 
 func TestMe(t *testing.T) {
-  authorizedRequest(t)
-  res, err := api.Me().Get(nil)
-  if err != nil {
-    t.Error(err)
-  } else if res.Id != TestConfig["my_id"].(uint64) {
-    t.Error("Idcheck failed", res)
-  }
+	authorizedRequest(t)
+	res, err := api.Me().Get(nil)
+	if err != nil {
+		t.Error(err)
+	} else if res.Id != TestConfig["my_id"].(uint64) {
+		t.Error("Idcheck failed", res)
+	}
 }

--- a/soundcloud/oauth.go
+++ b/soundcloud/oauth.go
@@ -10,10 +10,10 @@ func (api *Api) Refresh() error {
 	}
 
 	values := Values(
-		"client_id",     api.ClientId,
+		"client_id", api.ClientId,
 		"client_secret", api.ClientSecret,
 		"refresh_token", api.RefreshToken,
-		"grant_type",    "refresh_token",
+		"grant_type", "refresh_token",
 	)
 
 	ret := new(AuthResponse)
@@ -22,7 +22,7 @@ func (api *Api) Refresh() error {
 	if err == nil {
 		api.AccessToken = ret.AccessToken
 		api.RefreshToken = ret.RefreshToken
-  }
+	}
 
 	return err
 }

--- a/soundcloud/users.go
+++ b/soundcloud/users.go
@@ -20,7 +20,7 @@ func (api *Api) User(id uint64) *UserApi {
 
 func (u *UserApi) Get(params url.Values) (*User, error) {
 	ret := new(User)
-	err := u.api.get(u.base, params, ret)
+	err := u.api.get(u.base, params, ret, u.authReq)
 	return ret, err
 }
 


### PR DESCRIPTION
Great work on this library! It's been really useful so far.

I flipped the logic in extendParams and made use of authReq in UserApi.Get().

I also ran go fmt with default parameters, let me know if you prefer a different formatting!

Thanks,
Kevin