### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # golang-soundcloud
 
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/Soundcloud/functions?utm_source=SoundcloudGithub&utm_medium=button&utm_content=Vender_GitHub)
+
 A (_incomplete_) [SoundCloud](http://soundcloud.com) [API](http://developers.soundcloud.com) wrapper.
 
 ## Features


### PR DESCRIPTION
Hey there. I added a link to the README for a tool where you can test out the Soundcloud API calls in your browser. It's pretty cool because you can export the code snippet into multiple languages as well. I thought it would be useful because I've seen it on other SDKs (Telegram, Shopify and LinkedIn). Full disclosure--I do work on the team that built this tool, but honestly, people seem to find it useful for this kind of stuff.